### PR TITLE
[wip]ci: windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install Rclone
         run: |
-          winget install Rclone.Rclone
+          winget install Rclone.Rclone --disable-interactivity --accept-source-agreements
 
       - name: Build rclone_cpp
         working-directory: ${{ github.workspace }}\\rclone_cpp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,18 +77,20 @@ jobs:
 #      - name: Installing winget
 #        uses: Cyberboss/install-winget@v1
 
-      - name: Installing Python
+      - name: Install Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Installing cmake
-        uses: Symbitic/install-cmake@v0.1.1
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v2.0.2
 
-      - name: Setting up Conan
+      - name: Install Conan
         run: |
           python -m venv .\\venv
           .\\venv\\Scripts\\pip install conan
+          .\\venv\\Scripts\\conan profile new default --detect
+          .\\venv\\Scripts\\conan profile update settings.compiler.cppstd=17 default
           .\\venv\\Scripts\\conan profile detect
           git clone https://github.com/Sudo-Rahman/rclone_cpp.git
           mkdir qt
@@ -98,6 +100,11 @@ jobs:
         with:
           version: "6.4.2"
           modules: qtbase,qttools
+
+      - name: Install Rclone
+        run: |
+          winget install Rclone.Rclone
+          rclone version
 
       - name: Build rclone_cpp
         working-directory: ${{ github.workspace }}\\rclone_cpp
@@ -110,7 +117,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           .\\venv\\Scripts\\conan install . --build=missing
-          cmake --preset conan-release -DCMAKE_PREFIX_PATH="${{ env.QT_INSTALL_DIR }}\\lib\\cmake\\Qt6"
+          cmake --preset conan-release -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH="${{ env.QT_INSTALL_DIR }}\\lib\\cmake\\Qt6"
           cmake --build --parallel --preset conan-release
 
       - name: Caching package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Install Rclone
         run: |
           winget install Rclone.Rclone
-          rclone version
 
       - name: Build rclone_cpp
         working-directory: ${{ github.workspace }}\\rclone_cpp
@@ -120,11 +119,11 @@ jobs:
           cmake --preset conan-release -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH="${{ env.QT_INSTALL_DIR }}\\lib\\cmake\\Qt6"
           cmake --build --parallel --preset conan-release
 
-      - name: Caching package
+      - name: Caching executable
         uses: actions/upload-artifact@v4
         with:
           name: iridium-windows-package
-          path: package\\*.zip
+          path: build\\Release\\Iridium.exe
           retention-days: 1
 
 #
@@ -148,6 +147,12 @@ jobs:
           name: iridium-linux-package
           path: package/linux/
 
+      - name: Retrieve cached windows package
+        uses: actions/download-artifact@v4
+        with:
+          name: iridium-windows-package
+          path: package/windows/
+
       - name: Push tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -162,5 +167,7 @@ jobs:
           name: ${{ github.event.inputs.iridium_version }}
           draft: false
           prerelease: true
-          files: package/linux/*
+          files: |
+            package/linux/*
+            package/windows/*
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Update Conan profile to use C++17
         shell: pwsh
         run: |
-          $PROFILE_PATH = "$env:USERPROFILE\.conan\profiles\default"
+          $PROFILE_PATH = .\\venv\\Scripts\\conan profile path default
           $CPPSTD_SETTING = "compiler.cppstd=17"
           if (Get-Content $PROFILE_PATH | Select-String -Pattern "compiler.cppstd=") {
             (Get-Content $PROFILE_PATH) -replace "compiler.cppstd=.*", $CPPSTD_SETTING | Set-Content $PROFILE_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,11 +89,21 @@ jobs:
         run: |
           python -m venv .\\venv
           .\\venv\\Scripts\\pip install conan
-          .\\venv\\Scripts\\conan profile new default --detect
-          .\\venv\\Scripts\\conan profile update settings.compiler.cppstd=17 default
-          .\\venv\\Scripts\\conan profile detect
+          .\\venv\\Scripts\\conan profile detect  
           git clone https://github.com/Sudo-Rahman/rclone_cpp.git
           mkdir qt
+
+      - name: Update Conan profile to use C++17
+        shell: pwsh
+        run: |
+          $PROFILE_PATH = "$env:USERPROFILE\.conan\profiles\default"
+          $CPPSTD_SETTING = "compiler.cppstd=17"
+          if (Get-Content $PROFILE_PATH | Select-String -Pattern "compiler.cppstd=") {
+            (Get-Content $PROFILE_PATH) -replace "compiler.cppstd=.*", $CPPSTD_SETTING | Set-Content $PROFILE_PATH
+          } else {
+            Add-Content -Path $PROFILE_PATH -Value $CPPSTD_SETTING
+          }
+          Write-Host "Conan profile updated successfully"
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,11 +68,58 @@ jobs:
           path: package/*.deb
           retention-days: 1
 
-#  windows-build:
-#    runs-on: windows-latest
-#    steps:
-#      - name: Todo
-#        run: echo "TODO"
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+#      - name: Installing winget
+#        uses: Cyberboss/install-winget@v1
+
+      - name: Installing Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Installing cmake
+        uses: Symbitic/install-cmake@v0.1.1
+
+      - name: Setting up Conan
+        run: |
+          python -m venv .\\venv
+          .\\venv\\Scripts\\pip install conan
+          .\\venv\\Scripts\\conan profile detect
+          git clone https://github.com/Sudo-Rahman/rclone_cpp.git
+          mkdir qt
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: "6.4.2"
+          modules: qtbase,qttools
+
+      - name: Build rclone_cpp
+        working-directory: ${{ github.workspace }}\\rclone_cpp
+        run: |
+          git checkout ${{ github.event.inputs.rclone_cpp_version }}
+          ..\\venv\\Scripts\\conan install . --build=missing
+          ..\\venv\\Scripts\\conan create . --build=missing
+
+      - name: Build Iridium
+        working-directory: ${{ github.workspace }}
+        run: |
+          .\\venv\\Scripts\\conan install . --build=missing
+          cmake --preset conan-release -DCMAKE_PREFIX_PATH="${{ env.QT_INSTALL_DIR }}\\lib\\cmake\\Qt6"
+          cmake --build --parallel --preset conan-release
+
+      - name: Caching package
+        uses: actions/upload-artifact@v4
+        with:
+          name: iridium-windows-package
+          path: package\\*.zip
+          retention-days: 1
+
 #
 #  macos-build:
 #    runs-on: macos-latest
@@ -82,7 +129,7 @@ jobs:
 
   tag:
 #    needs: [ linux-build, windows-build, macos-build ]
-    needs: linux-build
+    needs: [ linux-build, windows-build ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-#      - name: Installing winget
-#        uses: Cyberboss/install-winget@v1
+      - name: Installing winget
+        uses: Cyberboss/install-winget@v1
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           .\\venv\\Scripts\\conan install . --build=missing
-          cmake --preset conan-release -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH="${{ env.QT_INSTALL_DIR }}\\lib\\cmake\\Qt6"
-          cmake --build --parallel --preset conan-release
+          cmake --preset conan-default -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH="${{ env.QT_INSTALL_DIR }}\\lib\\cmake\\Qt6"
+          cmake --build --parallel --preset conan-default
 
       - name: Caching executable
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Installing winget
-        uses: Cyberboss/install-winget@v1
+      - name: Installing choco
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -113,9 +114,9 @@ jobs:
 
       - name: Install Rclone
         run: |
-          winget install Rclone.Rclone --disable-interactivity --accept-source-agreements
+          choco install rclone -y
         env:
-          PATH: ${{env.PATH}};C:\\Program Files\\WinGet\\Links\\rclone.exe
+          PATH: ${{env.PATH}};C:\\ProgramData\\chocolatey\\bin\\rclone.exe
 
       - name: Build rclone_cpp
         working-directory: ${{ github.workspace }}\\rclone_cpp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Rclone
         run: |
-          choco install rclone -y
+          C:\\ProgramData\\Chocolatey\\bin\\choco.exe install rclone -y
         env:
           PATH: ${{env.PATH}};C:\\ProgramData\\chocolatey\\bin\\rclone.exe
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Install Rclone
         run: |
           winget install Rclone.Rclone --disable-interactivity --accept-source-agreements
+        env:
+          PATH: ${{env.PATH}};C:\\Program Files\\WinGet\\Links\\rclone.exe
 
       - name: Build rclone_cpp
         working-directory: ${{ github.workspace }}\\rclone_cpp


### PR DESCRIPTION
Suite de #8 , arrive a build Rclone.cpp mais ne passe pas les tests pour l'instant car rclone ne figure pas dans le PATH donc les appels à la commande ``rclone`` ne marche pas donc ne passe pas les tests.

Le build de Iridium est pas test encore, ça pètera sûrement parce qu'il manque des dépendances.

La PR est surtout là si jamais tu veux y jeter un oeil pour reprendre là où je me suis arrêter parce que je pense pas continuer honnêtement.